### PR TITLE
2Week

### DIFF
--- a/records/1Week_shinjaean.md
+++ b/records/1Week_shinjaean.md
@@ -88,6 +88,9 @@ Q. Spring Boot에서 Google OAuth API를 사용하기위한 application.yml 파�
   => service를 통해 repository.delete() 메소드를 실행하도록 구현했다. 프로그램이 실행은 되나 delete 쿼리가 실행이 안되는 문제 발생
 
   => service 클래스에 @Transactional(readOnly = true) 어노테이션이 사용되었으므로, 쓰기 작업(likeablePerson 객체 삭제)을 수행하는 메서드에 @Transactional(readOnly=false) 어노테이션을 추가해줘야 한다. "readOnly" 속성은 "false"가 디폴트 값이므로 생략가능
+- 문제없이 잘 실행 되다가, OS 업데이트 후 실행이 되지 않는다.
+
+  => 정확한 원인을 파악하지는 못 했지만, DB Driver를 mariaDB에서 MySQL로 변경해주니 다시 문제없이 실행된다. 
 
 - 문제없이 잘 실행 되다가, OS 업데이트 후 실행이 되지 않는다.
 
@@ -180,4 +183,4 @@ authorization-grant-type 속성을 authorization_code 로 지정해주니 네이
 
   => 호감 상대를 삭제할 때, 에러 발생. 
 
-  => form 태그 action url을 정상 작동하게 수정. form 태그에 delete 방식으로 요청하기 위한 input 태그를 추가 
+  => form 태그 action url을 정상 작동하게 수정. form 태그에 delete 방식으로 요청하기 위한 input 태그를 추가

--- a/records/2Week_shinjaean.md
+++ b/records/2Week_shinjaean.md
@@ -1,0 +1,167 @@
+### 미션 요구사항 분석 & 체크리스트
+
+---
+**필수미션**
+- 호감표시 할 때 예외처리 케이스 3가지 처리
+
+
+  1. case 4: 한명의 인스타회원이 다른 인스타회원에게 중복으로 호감표시를 할 수 없습니다.
+
+      예를들어 본인의 인스타ID가 aaaa, 상대의 인스타ID가 bbbb 라고 하자.
+      
+      aaaa 는 bbbb 에게 호감을 표시한다.(사유 : 외모)
+      
+      잠시 후 aaaa 는 bbbb 에게 다시 호감을 표시한다.(사유 : 외모)
+      
+      이 경우에는 처리되면 안된다.(rq.historyBack)
+
+
+  2. case 5: 한명의 인스타회원이 11명 이상의 호감상대를 등록 할 수 없습니다.
+    
+      예를들어 본인의 인스타ID가 aaaa 라고 하자.
+      
+      aaaa 는 bbbb, cccc, dddd, eeee, ffff, gggg, hhhh, iiii, jjjj, kkkk 에 대해서 호감표시를 했다.(사유는 상관없음, aaaa는 현재까지 10명에게 호감표시를 했음)
+      
+      잠시 후 aaaa 는 llll 에게 호감표시를 한다.(사유는 상관없음)
+      
+      이 경우에는 처리되면 안된다.(rq.historyBack)
+
+  3. case 6: "case 4" 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리한다.
+     
+      예를들어 본인의 인스타ID가 aaaa, 상대의 인스타ID가 bbbb 라고 하자.
+      
+      aaaa 는 bbbb 에게 호감을 표시한다.(사유 : 외모)
+      
+      잠시 후 aaaa 는 bbbb 에게 다시 호감을 표시한다.(사유 : 성격)
+      
+      이 경우에는 새 호감상대로 등록되지 않고, 기존 호감표시에서 사유만 수정된다.
+      
+      외모 => 성격
+      
+      resultCode=S-2
+      
+      msg=bbbb 에 대한 호감사유를 외모에서 성격으로 변경합니다.
+
+**선택미션**
+- 네이버 로그인
+
+  => 지난 주차 미션 제출 후 리팩토링 진행하면서 추가적으로 구현 완료
+
+### N주차 미션 요약
+
+---
+
+**📌 중복 호감 표시 제한**
+
+ => 현재 로그인한 사용자의 인스타 데이터를 이용하여 사용자의 호감 데이터를 전부 가져와 각 데이터들 중에 등록하고자 하는 이름이 호감 상대로 이미 등록되었는지 체크하고, 등록 되었다면 에러 메시지를, 아니라면 정상적인 등록 절차를 진행하도록 한다.
+
+**[구현]**
+- LikeablePersonController - 액션 메서드 add() 수정
+
+     => 서비스의 findByFromInstaMemberId() 메소드를 통해 사용자가 호감 표시하여 생성된 LikeablePerson 데이터를 전부 가져와서
+
+     => 모든 LikeablePerson 객체의 "toInstaMember.username"이 "addFrom.username"과 일치하는 데이터가 하나라도 존재하면
+
+     => 에러 메시지를 포함한 RsData를 인자로 가지는 Rq.historyBack() 메소드를 실행하여 실패 메시지와 함께 이전 페이지로 돌아가도록 구현했다.
+
+
+- Test Case 생성
+
+    => 이미 존재하는 호감 상대(insta_user4) 추가 시도. user3에게는 호감 표시한 상대가 2명(insta_user4, insta_user100) 존재한다. 
+
+    => 위 시뮬레이션 결과, 400 상태 코드(= 호감 상대 추가 실패)를 반환하는지 검증하고, 실제로 데이터의 개수가 기존 2개가 맞는지 검증하도록 구현했다.
+
+**📌 [11명 이상 호감 표시 제한]**
+
+ => 현재 로그인한 사용자의 인스타 데이터를 이용하여 사용자의 호감 데이터를 전부 가져와 List의 크기가 10이상이면, 에러 메시지를, 아니라면 정상 절차를 진행하도록 한다.
+
+**[구현]**
+- LikeablePersonController - 액션 메서드 add() 수정
+
+    => 서비스의 findByFromInstaMemberId() 메소드를 통해 사용자가 호감 표시하여 생성된 LikeablePerson 데이터를 전부 가져와 List의 사이즈가 10이상 인지 체크한다.
+
+    => List의 사이즈가 10이상 이면, 실패 메시지를 포함한 RsData를 인자로 가지는 Rq.historyBack() 메소드를 실행하여 실패 메시지와 함게 이전 페이지로 돌아가도록 구현
+
+
+- Test Case 생성
+
+    => 더미 데이터 8개 생성. user3의 기존 2개의 데이터와 합하여 총 10개의 데이터가 존재하게 된다.
+
+    => 11번째 호감 데이터 생성 시도.
+
+    => 위 시뮬레이션 결과, 400 상태 코드를 반환(데이터 생성 불가능)하는지 검증하고, 실제로 데이터가 10개에서 증가되지 않았는지 검증하도록 테스트를 구현했다.
+
+**[리팩토링]**
+
+ =>  사용자의 모든 호감 데이터를 가져온 리스트의 사이즈를 비교하는 부분에서 하드 코딩된 부분을 수정 했다.
+
+- application.yml 파일에 프로그램 내부에서 사용될 변하지 않는 변수를 정의
+
+- AppConfig class 생성
+
+    => @Configuration 어노테이션을 작성. likeablePersonFromMax 라는 필드와 해당 필드의 값을 초기화 해줄 setLikeablePersonFromMax() 메소드를 생성
+
+    => setLikeablePersonFromMax() 메소드에 @Value 어노테이션을 사용하여 application.yml 파일 속에 정의된 사용자 지정 변수(custom.likeablePerson.from.max = 10)를 해당 메소드에서 사용할 수 있다. 이 메소드에서는 세터 함수의 인자로 해당 데이터를 주입하게 된다.
+
+- 적용
+
+    => controller class에서 하드 코딩된 부분을 AppConfig.likeablerPersonFromMax 으로 교체. 필드를 static 선언했기 때문에 인스턴스화 없이 사용이 가능하다.
+
+
+**📌 [호감 사유 변경]**
+
+ => 중복 호감 표시가 발생했을 때, 호감 사유가 기존과 다르다면 바뀐 사유로 변경 작업을 진행한다.
+
+**[구현]**
+
+- LikeablePersonController - 액션 메서드 add() 수정
+
+    => 기존에 등록된 호감 표시 횟수가 10이상인지 먼저 체크했었는데, 중복을 먼저 체크하도록 코드의 순서를 변경했다. 
+
+    => 기존에 중복 호감 표시를 처리하는 과정 안에 기존 호감 표시의 호감 사유가 바뀌었는지 체크하고, 바뀌었다면 수정하도록 구현했다.
+
+
+- LikeablePersonService - modifyAttractionTypeCode() 메소드 생성
+
+    => ⚠️ 주의할 것. 메소드에 @Transactional 어노테이션 작성해줘야 정상적으로 DB에 내용이 반영됨
+
+    => 호감 이유(attractiveTypeCode)와 수정 날짜(modifyDate)를 세터를 통해 변경된 데이터로 세팅
+
+    => repository.save(entity) 세이브 메소드를 통해 변경된 객체 데이터를 다시 저장하도록 했다.
+
+    => 마지막으로 성공 결과 코드와 성공 메시지를 포함한 RsData 객체를 반환한다.
+
+
+-  LikeablePersonService - attractionTypeCodeToString() 메소드 생성
+
+    => 성공 메시지에는 "이전 attractionTypeCode"와 "변경된 attractionTypeCode"의 숫자 코드가 아닌 그와 상응하는 문자열(1=외모, 2=성격, 3=능력)이 필요하다.
+
+    => 타입 코드를 인자로 넘기면 그와 상응하는 문자열을 반환하도록 구현했다.  
+
+
+- LikeablePerson - Setter 설정
+
+    => modifyDate, attractiveTypeCode 두 필드에 대해서 변경된 값을 세팅하기 위해 세터가 필요. @Setter 어노테이션을 작성했다.
+
+
+- LikeablePersonServiceTests - modifyAttractionTypeCode() 메소드 테스트 생성
+
+    => 수정 기능이 제대로 작동하는지 검증하기 위한 테스트를 진행
+
+    => LikeablePerson 엔티티 중에서 아이디(기본키)가 1인 데이터를 가져와 modifyAttractionTypeCode() 메소드를 통해 attractionTypeCode를 1에서 2로 수정하고, 데이터가 2로 잘 변경되었는지 검증하도록 구현했다. 
+
+**[리팩토링]**
+
+ => 이전에 사용자의 모든 호감 표시 데이터를 가져온 리스트에서 toInstaMember의 username(변경하려는 인스타 멤버의 이름)이 일치하는 LikeablePerson 객체를 가져와서 수정을 진행했는데, 강사님 힌트를 듣고 리팩토링을 진행했다.
+
+- findByFromInstaMemberIdAndToInstaMember_username()
+
+    => 위 메소드는 fromInstaMemberId와 toInstaMember.username 두 가지 조건을 모두 만족하는 데이터를 추출하는 메소드이다.
+
+    => repository class에 명명 컨벤션(findBy[A]And[B])이 잘 지켜진 메소드 명을 작성
+
+    => service class에도 repository class에 id와 username을 전달하는 메소드를 작성
+
+    => controller class에서는 service class로 현재 사용자 인스타 아이디(primary key)와 addForm에서 작성한 호감 상대 인스타 아이디(username)를 전달하도록 구현
+
+**[특이사항]**

--- a/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
+++ b/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
@@ -1,0 +1,16 @@
+package com.ll.gramgram.base.appConfig;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+    @Getter
+    private static long likeablePersonFromMax;
+
+    @Value("${custom.likeablePerson.from.max}")
+    public void setLikeablePersonFromMax(long likeablePersonFromMax) {
+        AppConfig.likeablePersonFromMax = likeablePersonFromMax;
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -34,7 +34,7 @@ public class InstaMember {
     private String username;
     @Setter
     private String gender;
-    @OneToMany(mappedBy = "fromInstaMe가mber", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "fromInstaMember", cascade = CascadeType.ALL)
     @OrderBy("id desc")
     @LazyCollection(LazyCollectionOption.EXTRA)
     @Builder.Default

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -24,6 +24,7 @@ public class LikeablePerson {
     private Long id;
     @CreatedDate
     private LocalDateTime createDate;
+    @Setter
     @LastModifiedDate
     private LocalDateTime modifyDate;
     @ToString.Exclude
@@ -34,6 +35,7 @@ public class LikeablePerson {
     @ManyToOne
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
+    @Setter
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)
 
     public String getAttractiveTypeDisplayName() {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -4,7 +4,10 @@ import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
+
+    Optional<LikeablePerson> findByFromInstaMemberIdAndToInstaMember_username(Long instaMemberId, String toInstaMemberUsername);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,7 +48,7 @@ public class LikeablePersonService {
         fromInstaMember.addFromLikeablePerson(likeablePerson);
         toInstaMember.addToLikeablePerson(likeablePerson);
 
-        return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
+        return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록하였습니다.".formatted(username), likeablePerson);
     }
 
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
@@ -72,5 +73,29 @@ public class LikeablePersonService {
 
     public Optional<LikeablePerson> findById(Long id) {
         return likeablePersonRepository.findById(id);
+    }
+
+    @Transactional
+    public RsData<LikeablePerson> modifyAttractionTypeCode(LikeablePerson likeablePerson, int attractionTypeCode){
+        String beforeAttractionType = attractionTypeCodeToString(likeablePerson.getAttractiveTypeCode());
+        String afterAttractionType = attractionTypeCodeToString(attractionTypeCode);
+        likeablePerson.setAttractiveTypeCode(attractionTypeCode);
+        likeablePerson.setModifyDate(LocalDateTime.now());
+        likeablePersonRepository.save(likeablePerson);
+        return RsData.of("S-2", "%s에 대한 호감 사유를 %s에서 %s(으)로 변경합니다.".formatted(likeablePerson.getToInstaMember().getUsername(), beforeAttractionType, afterAttractionType));
+    }
+
+    public String attractionTypeCodeToString(int attractionTypeCode) {
+        String attractionType;
+        switch (attractionTypeCode) {
+            case 1 -> attractionType = "외모";
+            case 2 -> attractionType = "성격";
+            default -> attractionType = "능력";
+        }
+        return attractionType;
+    }
+
+    public Optional<LikeablePerson> findByFromInstaMemberIdAndToInstaMember_username(Long instaMemberId, String toInstaMemberUsername) {
+        return likeablePersonRepository.findByFromInstaMemberIdAndToInstaMember_username(instaMemberId, toInstaMemberUsername);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,7 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.security: trace
+custom:
+  LikeablePerson:
+    from:
+      max: 10

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -2,6 +2,8 @@ package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
+import com.ll.gramgram.boundedContext.member.entity.Member;
+import com.ll.gramgram.boundedContext.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -28,7 +32,9 @@ public class LikeablePersonControllerTests {
     @Autowired
     private MockMvc mvc;
     @Autowired
-    private LikeablePersonService likeablePersonSerivce;
+    private LikeablePersonService likeablePersonService;
+    @Autowired
+    private MemberService memberService;
 
     @Test
     @DisplayName("등록 폼(인스타 인증을 안해서 폼 대신 메세지)")
@@ -197,6 +203,55 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().is4xxClientError());
-        assertThat(likeablePersonSerivce.findById(1L).isPresent()).isTrue();
+        assertThat(likeablePersonService.findById(1L).isPresent()).isTrue();
+    }
+    @Test
+    @DisplayName("호감표시(중복, 결과: 실패)")
+    @WithUserDetails("user3")
+    void t009() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "2")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        assertThat(likeablePersonService.findByFromInstaMemberId(2L).size()).isEqualTo(2);
+    }
+    @Test
+    @DisplayName("호감 표시(11명 이상, 결과: 실패)")
+    @WithUserDetails("user3")
+    void t010() throws Exception {
+        Optional<Member> member = memberService.findByUsername("user3");
+        //더미 데이터 8개(insta_user5 ~ insta_user12) 생성.
+        for (int i = 5; i < 13; i++) {
+            likeablePersonService.like(member.get(), "insta_user%d".formatted(i), 1);
+        }
+        //기존 데이터 2개와 합하여 총 10개의 데이터가 존재하게 된다.
+        assertThat(likeablePersonService.findByFromInstaMemberId(2L).size()).isEqualTo(10);
+
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user13")
+                        .param("attractiveTypeCode", "2")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        //데이터가 10개에서 증가되지 않았는지 체크
+        assertThat(likeablePersonService.findByFromInstaMemberId(2L).size()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -1,0 +1,22 @@
+package com.ll.gramgram.boundedContext.likeablePerson.service;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class LikeablePersonServiceTests {
+    @Autowired
+    private LikeablePersonService likeablePersonService;
+    @Test
+    @DisplayName("modifyAttractionTypeCode() Test")
+    void t001() {
+        LikeablePerson likeablePerson = likeablePersonService.findById(1L).get();
+        likeablePersonService.modifyAttractionTypeCode(likeablePerson, 2);
+        assertThat(likeablePersonService.findById(1L).get().getAttractiveTypeCode()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
### 미션 요구사항 분석 & 체크리스트

---
**필수미션**
- 호감표시 할 때 예외처리 케이스 3가지 처리


  1. case 4: 한명의 인스타회원이 다른 인스타회원에게 중복으로 호감표시를 할 수 없습니다.

      예를들어 본인의 인스타ID가 aaaa, 상대의 인스타ID가 bbbb 라고 하자.
      
      aaaa 는 bbbb 에게 호감을 표시한다.(사유 : 외모)
      
      잠시 후 aaaa 는 bbbb 에게 다시 호감을 표시한다.(사유 : 외모)
      
      이 경우에는 처리되면 안된다.(rq.historyBack)


  2. case 5: 한명의 인스타회원이 11명 이상의 호감상대를 등록 할 수 없습니다.
    
      예를들어 본인의 인스타ID가 aaaa 라고 하자.
      
      aaaa 는 bbbb, cccc, dddd, eeee, ffff, gggg, hhhh, iiii, jjjj, kkkk 에 대해서 호감표시를 했다.(사유는 상관없음, aaaa는 현재까지 10명에게 호감표시를 했음)
      
      잠시 후 aaaa 는 llll 에게 호감표시를 한다.(사유는 상관없음)
      
      이 경우에는 처리되면 안된다.(rq.historyBack)

  3. case 6: "case 4" 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리한다.
     
      예를들어 본인의 인스타ID가 aaaa, 상대의 인스타ID가 bbbb 라고 하자.
      
      aaaa 는 bbbb 에게 호감을 표시한다.(사유 : 외모)
      
      잠시 후 aaaa 는 bbbb 에게 다시 호감을 표시한다.(사유 : 성격)
      
      이 경우에는 새 호감상대로 등록되지 않고, 기존 호감표시에서 사유만 수정된다.
      
      외모 => 성격
      
      resultCode=S-2
      
      msg=bbbb 에 대한 호감사유를 외모에서 성격으로 변경합니다.

**선택미션**
- 네이버 로그인

  => 지난 주차 미션 제출 후 리팩토링 진행하면서 추가적으로 구현 완료

### N주차 미션 요약

---

**📌 중복 호감 표시 제한**

 => 현재 로그인한 사용자의 인스타 데이터를 이용하여 사용자의 호감 데이터를 전부 가져와 각 데이터들 중에 등록하고자 하는 이름이 호감 상대로 이미 등록되었는지 체크하고, 등록 되었다면 에러 메시지를, 아니라면 정상적인 등록 절차를 진행하도록 한다.

**[구현]**
- LikeablePersonController - 액션 메서드 add() 수정

     => 서비스의 findByFromInstaMemberId() 메소드를 통해 사용자가 호감 표시하여 생성된 LikeablePerson 데이터를 전부 가져와서

     => 모든 LikeablePerson 객체의 "toInstaMember.username"이 "addFrom.username"과 일치하는 데이터가 하나라도 존재하면

     => 에러 메시지를 포함한 RsData를 인자로 가지는 Rq.historyBack() 메소드를 실행하여 실패 메시지와 함께 이전 페이지로 돌아가도록 구현했다.


- Test Case 생성

    => 이미 존재하는 호감 상대(insta_user4) 추가 시도. user3에게는 호감 표시한 상대가 2명(insta_user4, insta_user100) 존재한다. 

    => 위 시뮬레이션 결과, 400 상태 코드(= 호감 상대 추가 실패)를 반환하는지 검증하고, 실제로 데이터의 개수가 기존 2개가 맞는지 검증하도록 구현했다.

**📌 [11명 이상 호감 표시 제한]**

 => 현재 로그인한 사용자의 인스타 데이터를 이용하여 사용자의 호감 데이터를 전부 가져와 List의 크기가 10이상이면, 에러 메시지를, 아니라면 정상 절차를 진행하도록 한다.

**[구현]**
- LikeablePersonController - 액션 메서드 add() 수정

    => 서비스의 findByFromInstaMemberId() 메소드를 통해 사용자가 호감 표시하여 생성된 LikeablePerson 데이터를 전부 가져와 List의 사이즈가 10이상 인지 체크한다.

    => List의 사이즈가 10이상 이면, 실패 메시지를 포함한 RsData를 인자로 가지는 Rq.historyBack() 메소드를 실행하여 실패 메시지와 함게 이전 페이지로 돌아가도록 구현


- Test Case 생성

    => 더미 데이터 8개 생성. user3의 기존 2개의 데이터와 합하여 총 10개의 데이터가 존재하게 된다.

    => 11번째 호감 데이터 생성 시도.

    => 위 시뮬레이션 결과, 400 상태 코드를 반환(데이터 생성 불가능)하는지 검증하고, 실제로 데이터가 10개에서 증가되지 않았는지 검증하도록 테스트를 구현했다.

**[리팩토링]**

 =>  사용자의 모든 호감 데이터를 가져온 리스트의 사이즈를 비교하는 부분에서 하드 코딩된 부분을 수정 했다.

- application.yml 파일에 프로그램 내부에서 사용될 변하지 않는 변수를 정의

- AppConfig class 생성

    => @Configuration 어노테이션을 작성. likeablePersonFromMax 라는 필드와 해당 필드의 값을 초기화 해줄 setLikeablePersonFromMax() 메소드를 생성

    => setLikeablePersonFromMax() 메소드에 @Value 어노테이션을 사용하여 application.yml 파일 속에 정의된 사용자 지정 변수(custom.likeablePerson.from.max = 10)를 해당 메소드에서 사용할 수 있다. 이 메소드에서는 세터 함수의 인자로 해당 데이터를 주입하게 된다.

- 적용

    => controller class에서 하드 코딩된 부분을 AppConfig.likeablerPersonFromMax 으로 교체. 필드를 static 선언했기 때문에 인스턴스화 없이 사용이 가능하다.


**📌 [호감 사유 변경]**

 => 중복 호감 표시가 발생했을 때, 호감 사유가 기존과 다르다면 바뀐 사유로 변경 작업을 진행한다.

**[구현]**

- LikeablePersonController - 액션 메서드 add() 수정

    => 기존에 등록된 호감 표시 횟수가 10이상인지 먼저 체크했었는데, 중복을 먼저 체크하도록 코드의 순서를 변경했다. 

    => 기존에 중복 호감 표시를 처리하는 과정 안에 기존 호감 표시의 호감 사유가 바뀌었는지 체크하고, 바뀌었다면 수정하도록 구현했다.


- LikeablePersonService - modifyAttractionTypeCode() 메소드 생성

    => ⚠️ 주의할 것. 메소드에 @Transactional 어노테이션 작성해줘야 정상적으로 DB에 내용이 반영됨

    => 호감 이유(attractiveTypeCode)와 수정 날짜(modifyDate)를 세터를 통해 변경된 데이터로 세팅

    => repository.save(entity) 세이브 메소드를 통해 변경된 객체 데이터를 다시 저장하도록 했다.

    => 마지막으로 성공 결과 코드와 성공 메시지를 포함한 RsData 객체를 반환한다.


-  LikeablePersonService - attractionTypeCodeToString() 메소드 생성

    => 성공 메시지에는 "이전 attractionTypeCode"와 "변경된 attractionTypeCode"의 숫자 코드가 아닌 그와 상응하는 문자열(1=외모, 2=성격, 3=능력)이 필요하다.

    => 타입 코드를 인자로 넘기면 그와 상응하는 문자열을 반환하도록 구현했다.  


- LikeablePerson - Setter 설정

    => modifyDate, attractiveTypeCode 두 필드에 대해서 변경된 값을 세팅하기 위해 세터가 필요. @Setter 어노테이션을 작성했다.


- LikeablePersonServiceTests - modifyAttractionTypeCode() 메소드 테스트 생성

    => 수정 기능이 제대로 작동하는지 검증하기 위한 테스트를 진행

    => LikeablePerson 엔티티 중에서 아이디(기본키)가 1인 데이터를 가져와 modifyAttractionTypeCode() 메소드를 통해 attractionTypeCode를 1에서 2로 수정하고, 데이터가 2로 잘 변경되었는지 검증하도록 구현했다. 

**[리팩토링]**

 => 이전에 사용자의 모든 호감 표시 데이터를 가져온 리스트에서 toInstaMember의 username(변경하려는 인스타 멤버의 이름)이 일치하는 LikeablePerson 객체를 가져와서 수정을 진행했는데, 강사님 힌트를 듣고 리팩토링을 진행했다.

- findByFromInstaMemberIdAndToInstaMember_username()

    => 위 메소드는 fromInstaMemberId와 toInstaMember.username 두 가지 조건을 모두 만족하는 데이터를 추출하는 메소드이다.

    => repository class에 명명 컨벤션(findBy[A]And[B])이 잘 지켜진 메소드 명을 작성

    => service class에도 repository class에 id와 username을 전달하는 메소드를 작성

    => controller class에서는 service class로 현재 사용자 인스타 아이디(primary key)와 addForm에서 작성한 호감 상대 인스타 아이디(username)를 전달하도록 구현

**[특이사항]**
